### PR TITLE
Prevent p.drawText() TypeError

### DIFF
--- a/src/gui/Widgets/mapwidget.py
+++ b/src/gui/Widgets/mapwidget.py
@@ -136,4 +136,4 @@ class MapWidget(QWidget):
         text = 'Load an OSM file to begin!'
         fm = p.fontMetrics()
         w, h = fm.width(text), fm.height()
-        p.drawText(self.width()/2-w/2, self.height()/2+h/2, text)
+        p.drawText(int(self.width()/2-w/2), int(self.height()/2+h/2), text)


### PR DESCRIPTION
Casting the arguments to int will prevent the TypeError, as it does not expect arguments of type "float".
See issue #7.